### PR TITLE
Fixed pyrocpu.png resizing on the landing page

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -75,7 +75,7 @@ const HeroSection = () => {
             />
           </div>
         </div>
-        <div className="absolute top-1/2 h-[400px] w-[400px] -translate-y-1/2">
+        {/* <div className="absolute top-1/2 h-[400px] w-[400px] -translate-y-1/2">
           <div className="cpulights -z-10">
             <div></div>
             <div></div>
@@ -243,7 +243,7 @@ const HeroSection = () => {
               <stop stopColor="transparent" offset="100%"></stop>
             </linearGradient>
           </defs>
-        </svg>
+        </svg> */}
         {/* <HeroImages /> */}
       </div>
       <div
@@ -286,6 +286,176 @@ const HeroSection = () => {
                 textShadow: "0 2px 16px rgba(174,207,242,.24)",
               }}
             >
+              <div className="flex justify-center items-center h-[406px]">
+                <div className="absolute cpulights -z-10">
+                  <div></div>
+                  <div></div>
+                </div>
+                <Image
+                  alt=""
+                  className="absolute z-[200]"
+                  aria-hidden
+                  src="/img/pyrocpu.png"
+                  width={400}
+                  height={400}
+                  quality={100}
+                />
+                <svg
+                  className=""
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 1920 700"
+                  fill="none"
+                >
+                  <path
+                    d="M1 3.00354C179.628 198.347 377.216 285 632.684 285C888.152 285 973.973 285 1290.31 285C1606.65 285 1797.76 143.751 1921 1.00002"
+                    stroke="url(#path)"
+                    vectorEffect="non-scaling-stroke"
+                  ></path>
+                  <path
+                    d="M1 197.5C185.5 282.5 336 320 631 320C926 320 980 320 1291 320C1602 320 1746.5 276.5 1921 197.5"
+                    stroke="url(#path)"
+                    vectorEffect="non-scaling-stroke"
+                  ></path>
+                  <path
+                    d="M1 354H1921"
+                    stroke="url(#path)"
+                    vectorEffect="non-scaling-stroke"
+                  ></path>
+                  <path
+                    d="M1 510C185.5 425 336 387.5 631 387.5C926 387.5 980 387.5 1291 387.5C1602 387.5 1746.5 431 1921 510"
+                    stroke="url(#path)"
+                    vectorEffect="non-scaling-stroke"
+                  ></path>
+                  <path
+                    d="M1 704.996C179.628 509.653 377.216 423 632.684 423C888.152 423 973.973 423 1290.31 423C1606.65 423 1797.76 564.249 1921 707"
+                    stroke="url(#path)"
+                    vectorEffect="non-scaling-stroke"
+                  ></path>
+                  <line
+                    x1="0"
+                    y1="0"
+                    x2="80"
+                    y2="0"
+                    stroke="url(#datum)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    transform="translate(-80,0)"
+                    vectorEffect="non-scaling-stroke"
+                  >
+                    <animateMotion
+                      dur="3s"
+                      repeatCount="indefinite"
+                      path="M1 3.00354C179.628 198.347 377.216 285 632.684 285C888.152 285 973.973 285 1290.31 285C1606.65 285 1797.76 143.751 1921 1.00002"
+                      rotate="auto"
+                      begin="1"
+                    ></animateMotion>
+                  </line>
+                  <line
+                    x1="0"
+                    y1="0"
+                    x2="80"
+                    y2="0"
+                    stroke="url(#datum)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    transform="translate(-80,0)"
+                    vectorEffect="non-scaling-stroke"
+                  >
+                    <animateMotion
+                      dur="2.5s"
+                      repeatCount="indefinite"
+                      path="M1 197.5C185.5 282.5 336 320 631 320C926 320 980 320 1291 320C1602 320 1746.5 276.5 1921 197.5"
+                      rotate="auto"
+                      begin="5"
+                    ></animateMotion>
+                  </line>
+                  <line
+                    x1="0"
+                    y1="0"
+                    x2="80"
+                    y2="0"
+                    stroke="url(#datum)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    transform="translate(-80,0)"
+                    vectorEffect="non-scaling-stroke"
+                  >
+                    <animateMotion
+                      dur="4s"
+                      repeatCount="indefinite"
+                      path="M1 354H1921"
+                      rotate="auto"
+                      begin="3"
+                    ></animateMotion>
+                  </line>
+                  <line
+                    x1="0"
+                    y1="0"
+                    x2="80"
+                    y2="0"
+                    stroke="url(#datum)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    transform="translate(-80,0)"
+                    vectorEffect="non-scaling-stroke"
+                  >
+                    <animateMotion
+                      dur="3.5s"
+                      repeatCount="indefinite"
+                      path="M1 510C185.5 425 336 387.5 631 387.5C926 387.5 980 387.5 1291 387.5C1602 387.5 1746.5 431 1921 510"
+                      rotate="auto"
+                      begin="2"
+                    ></animateMotion>
+                  </line>
+                  <line
+                    x1="0"
+                    y1="0"
+                    x2="80"
+                    y2="0"
+                    stroke="url(#datum)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    transform="translate(-80,0)"
+                    vectorEffect="non-scaling-stroke"
+                  >
+                    <animateMotion
+                      dur="4.5s"
+                      repeatCount="indefinite"
+                      path="M1 704.996C179.628 509.653 377.216 423 632.684 423C888.152 423 973.973 423 1290.31 423C1606.65 423 1797.76 564.249 1921 707"
+                      rotate="auto"
+                      begin="0"
+                    ></animateMotion>
+                  </line>
+                  <defs>
+                    <linearGradient
+                      id="datum"
+                      x1="0"
+                      y1="0"
+                      x2="80"
+                      y2="0"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="transparent " offset="0"></stop>
+                      <stop stopColor="#fa4e49" offset="1"></stop>
+                    </linearGradient>
+                    <linearGradient
+                      id="path"
+                      x1="0"
+                      y1="0"
+                      x2="100%"
+                      y2="0"
+                      gradientUnits="userSpaceOnUse"
+                    >
+                      <stop stopColor="transparent " offset="0%"></stop>
+                      <stop stopColor="#291111" offset="10%"></stop>
+                      <stop stopColor="#29111166" offset="90%"></stop>
+                      <stop stopColor="transparent" offset="100%"></stop>
+                    </linearGradient>
+                  </defs>
+                </svg>
+              </div>
+            {/* <div className="w-[400px] h-[400px]"></div> */}
               It&apos;s where your world plays
             </span>
             {/* </BrandText> */}

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -455,7 +455,6 @@ const HeroSection = () => {
                   </defs>
                 </svg>
               </div>
-            {/* <div className="w-[400px] h-[400px]"></div> */}
               It&apos;s where your world plays
             </span>
             {/* </BrandText> */}


### PR DESCRIPTION
There's an issue on the landing page that shows pyrocpu.png as this:

![image](https://github.com/pyrohost/web/assets/26689496/2cee28ae-7182-44b4-b8b8-bff3f43b0e93)

So, I decided to take some time to fix it, so it looks like this:

![image](https://github.com/pyrohost/web/assets/26689496/f01ba391-e4e4-4742-8fe8-698ce13f750b)

![image](https://github.com/pyrohost/web/assets/26689496/f171d632-5acd-4bcb-8be6-7bce554db40e)

![image](https://github.com/pyrohost/web/assets/26689496/659c3de8-0fb2-4faa-bb87-6fe0ceb2c46f)
